### PR TITLE
New FallbackResponseHandler property

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -106,6 +106,11 @@ namespace RichardSzalay.MockHttp
                 }
             }
 
+            if (FallbackResponseHandler != null)
+            {
+                return TaskEx.FromResult(FallbackResponseHandler(request));
+            }
+
             return TaskEx.FromResult(FallbackResponse);
         }
 
@@ -126,6 +131,8 @@ namespace RichardSzalay.MockHttp
                     return handler.SendAsync(request, cancellationToken);
                 }).Unwrap();
         }
+
+        public Func<HttpRequestMessage, HttpResponseMessage> FallbackResponseHandler { get; set; }
 
         private HttpResponseMessage fallbackResponse = null;
 


### PR DESCRIPTION
New FallbackResponseHandler property allows us to create fallback messages based on request messages.

This is great when a user wants the fallback handler to report unmatched URLs for example.
