### PR TITLE
QueryStringMatcher and FormDataMatcher will correctly unescape data

### DIFF
--- a/RichardSzalay.MockHttp.Shared/Matchers/QueryStringMatcher.cs
+++ b/RichardSzalay.MockHttp.Shared/Matchers/QueryStringMatcher.cs
@@ -49,10 +49,16 @@ namespace RichardSzalay.MockHttp.Matchers
             return input.TrimStart('?').Split('&')
                 .Select(pair => StringUtil.Split(pair, '=', 2))
                 .Select(pair => new KeyValuePair<string, string>(
-                    Uri.UnescapeDataString(pair[0]),
-                    pair.Length == 2 ? Uri.UnescapeDataString(pair[1]) : ""
+                    UrlDecode(pair[0]),
+                    pair.Length == 2 ? UrlDecode(pair[1]) : ""
                     ))
                 .ToList();
+        }
+
+        internal static string UrlDecode(string urlEncodedValue)
+        {
+            string tmp = urlEncodedValue.Replace("+", "%20");
+            return Uri.UnescapeDataString(tmp);
         }
     }
 }

--- a/RichardSzalay.MockHttp.Tests/Matchers/FormDataMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/FormDataMatcherTests.cs
@@ -103,6 +103,36 @@ namespace RichardSzalay.MockHttp.Tests.Matchers
         }
 
         [Fact]
+        public void Should_support_matching_dictionary_data_with_url_encoded_values1()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key", "Value with spaces");
+
+            var content = new FormUrlEncodedContent(data);
+
+            var sut = new FormDataMatcher(data);
+
+            var actualMatch = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org/home") { Content = content });
+
+            Assert.True(actualMatch, "FormDataMatcher.Matches() should match dictionary data with URL encoded query string values.");
+        }
+
+        [Fact]
+        public void Should_support_matching_dictionary_data_with_url_encoded_values2()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key", "Value with spaces");
+
+            var content = new FormUrlEncodedContent(data);
+
+            var sut = new FormDataMatcher("key=Value+with%20spaces");
+
+            var actualMatch = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org/home") { Content = content });
+
+            Assert.True(actualMatch, "FormDataMatcher.Matches() should match dictionary data with URL encoded query string values.");
+        }
+
+        [Fact]
         public void Should_fail_for_non_form_data()
         {
             var content = new FormUrlEncodedContent(HttpHelpers.ParseQueryString("key=value"));

--- a/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
@@ -88,6 +88,21 @@ namespace RichardSzalay.MockHttp.Tests.Matchers
             Assert.True(result);
         }
 
+        [Fact]
+        public void Should_support_matching_dictionary_data_with_url_encoded_values()
+        {
+            var data = new Dictionary<string, string>();
+            data.Add("key", "Value with spaces");
+
+            var qs = "key=Value+with%20spaces";
+
+            var sut = new QueryStringMatcher(data);
+
+            var actualMatch = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org/home?" + qs));
+
+            Assert.True(actualMatch, "QueryStringMatcher.Matches() should match dictionary data with URL encoded query string values.");
+        }
+
         private bool Test(string expected, string actual)
         {
             var sut = new QueryStringMatcher(expected);


### PR DESCRIPTION
QueryStringMatcher and FormDataMatcher will correctly unescape data that contain + sign.

Fixed #5 