### PR TITLE
Make the HeadersMatcher also check content headers

### DIFF
--- a/RichardSzalay.MockHttp.Shared/Matchers/HeadersMatcher.cs
+++ b/RichardSzalay.MockHttp.Shared/Matchers/HeadersMatcher.cs
@@ -40,11 +40,14 @@ namespace RichardSzalay.MockHttp.Matchers
         /// <returns>true if the request was matched; false otherwise</returns>
         public bool Matches(HttpRequestMessage message)
         {
-            return this.headers.All(h => MatchesHeader(h, message.Headers));
+            return this.headers.All(h => MatchesHeader(h, message.Headers) || MatchesHeader(h, message.Content?.Headers));
         }
 
-        private bool MatchesHeader(KeyValuePair<string, string> matchHeader, System.Net.Http.Headers.HttpRequestHeaders messageHeader)
+        private bool MatchesHeader(KeyValuePair<string, string> matchHeader, System.Net.Http.Headers.HttpHeaders messageHeader)
         {
+            if (messageHeader == null)
+                return false;
+
             IEnumerable<string> values;
 
             if (!messageHeader.TryGetValues(matchHeader.Key, out values))

--- a/RichardSzalay.MockHttp.Tests/Matchers/HeadersMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/HeadersMatcherTests.cs
@@ -19,13 +19,15 @@ namespace RichardSzalay.MockHttp.Tests.Matchers
                 expected: new HeadersMatcher(new Dictionary<string, string>
                     {
                         { "Authorization", "Basic abcdef" },
-                        { "Accept", "application/json" }
+                        { "Accept", "application/json" },
+                        { "Content-Type", "text/plain; charset=utf-8" }
                     }),
                 actual: req =>
                 {
                     req.Headers.Authorization = new AuthenticationHeaderValue("Basic", "abcdef");
                     req.Headers.Accept.Clear();
                     req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    req.Content = new StringContent("test", Encoding.UTF8, "text/plain");
                 }
                 );
 


### PR DESCRIPTION
This allows for checking for things like Content-Type which are on the request content instead of the actual request object