### PR TITLE
MockedRequestExtensions: Allow response headers to be added

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockedRequestExtensions.cs
+++ b/RichardSzalay.MockHttp.Shared/MockedRequestExtensions.cs
@@ -4,8 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
-using System.Threading.Tasks;
 using RichardSzalay.MockHttp.Matchers;
 
 namespace RichardSzalay.MockHttp
@@ -279,9 +279,29 @@ namespace RichardSzalay.MockHttp
         /// <param name="content">The content of the response</param>
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, HttpContent content)
         {
-            return source.Respond(req => new HttpResponseMessage(statusCode)
+            return source.Respond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), content);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="content">The content of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, HttpContent content)
+        {
+            return source.Respond(req =>
             {
-                Content = content
+                var res = new HttpResponseMessage(statusCode)
+                {
+                    Content = content
+                };
+                foreach (var header in headers)
+                {
+                    res.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+                return res;
             });
         }
 
@@ -296,15 +316,39 @@ namespace RichardSzalay.MockHttp
         }
 
         /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>, with an OK (200) status code
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="content">The content of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, IEnumerable<KeyValuePair<string, string>> headers, HttpContent content)
+        {
+            return source.Respond(HttpStatusCode.OK, headers, content);
+        }
+
+        /// <summary>
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
         /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
-        /// <param name="content">The content of the response</param>
         /// <param name="mediaType">The media type of the response</param>
+        /// <param name="content">The content of the response</param>
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, string mediaType, string content)
         {
-            return source.Respond(statusCode, _ => new StringContent(content, Encoding.UTF8, mediaType));
+            return source.Respond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), mediaType, content);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="mediaType">The media type of the response</param>
+        /// <param name="content">The content of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, string content)
+        {
+            return source.Respond(statusCode, headers, _ => new StringContent(content, Encoding.UTF8, mediaType));
         }
 
         /// <summary>
@@ -319,6 +363,18 @@ namespace RichardSzalay.MockHttp
         }
 
         /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>, with an OK (200) status code
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="content">The content of the response</param>
+        /// <param name="mediaType">The media type of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, string content)
+        {
+            return source.Respond(HttpStatusCode.OK, headers, mediaType, content);
+        }
+
+        /// <summary>
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
@@ -327,7 +383,20 @@ namespace RichardSzalay.MockHttp
         /// <param name="mediaType">The media type of the response</param>
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, string mediaType, Stream content)
         {
-            return source.Respond(statusCode, _ =>
+            return source.Respond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), mediaType, content);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="content">The content of the response</param>
+        /// <param name="mediaType">The media type of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, Stream content)
+        {
+            return source.Respond(statusCode, headers, _ =>
             {
                 if (content.CanSeek)
                 {
@@ -339,7 +408,7 @@ namespace RichardSzalay.MockHttp
                 ms.Seek(0L, SeekOrigin.Begin);
 
                 var streamContent = new StreamContent(ms);
-                streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType);
+                streamContent.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
                 return streamContent;
             });
@@ -360,17 +429,42 @@ namespace RichardSzalay.MockHttp
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="mediaType">The media type of the response</param>
+        /// <param name="handler">A delegate that will return a content stream at runtime</param>
+        public static MockedRequest Respond(this MockedRequest source, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, Func<HttpRequestMessage, Stream> handler)
+        {
+            return source.Respond(HttpStatusCode.OK, headers, mediaType, handler);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
         /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
         /// <param name="mediaType">The media type of the response</param>
         /// <param name="handler">A delegate that will return a content stream at runtime</param>
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, string mediaType, Func<HttpRequestMessage, Stream> handler)
         {
-            return source.Respond(statusCode, request =>
+            return source.Respond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), mediaType, handler);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="mediaType">The media type of the response</param>
+        /// <param name="handler">A delegate that will return a content stream at runtime</param>
+        public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, Func<HttpRequestMessage, Stream> handler)
+        {
+            return source.Respond(statusCode, headers, request =>
             {
                 var content = handler(request);
 
                 var streamContent = new StreamContent(content);
-                streamContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType);
+                streamContent.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
 
                 return streamContent;
             });
@@ -388,6 +482,18 @@ namespace RichardSzalay.MockHttp
         }
 
         /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>, with an OK (200) status code
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="content">The content of the response</param>
+        /// <param name="mediaType">The media type of the response</param>
+        public static MockedRequest Respond(this MockedRequest source, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, Stream content)
+        {
+            return source.Respond(HttpStatusCode.OK, headers, mediaType, content);
+        }
+
+        /// <summary>
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
@@ -401,13 +507,44 @@ namespace RichardSzalay.MockHttp
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="handler">The delegate that will return a <see cref="T:HttpContent"/> determined at runtime</param>
+        public static MockedRequest Respond(this MockedRequest source, IEnumerable<KeyValuePair<string, string>> headers, Func<HttpRequestMessage, HttpContent> handler)
+        {
+            return source.Respond(HttpStatusCode.OK, headers, handler);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
         /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
         /// <param name="handler">The delegate that will return a <see cref="T:HttpContent"/> determined at runtime</param>
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, Func<HttpRequestMessage, HttpContent> handler)
         {
-            return source.Respond(req => new HttpResponseMessage(statusCode)
+            return source.Respond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), handler);
+        }
+
+        /// <summary>
+        /// Sets the response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="handler">The delegate that will return a <see cref="T:HttpContent"/> determined at runtime</param>
+        public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, Func<HttpRequestMessage, HttpContent> handler)
+        {
+            return source.Respond(req =>
             {
-                Content = handler(req)
+                var res = new HttpResponseMessage(statusCode)
+                {
+                    Content = handler(req),
+                };
+                foreach (var header in headers)
+                {
+                    res.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+                return res;
             });
         }
 
@@ -461,7 +598,7 @@ namespace RichardSzalay.MockHttp
 
             cloned.Content = message.Content;
 
-            foreach(var header in message.Headers)
+            foreach (var header in message.Headers)
             {
                 cloned.Headers.Add(header.Key, header.Value);
             }

--- a/RichardSzalay.MockHttp.Tests/MockedRequestExtentionsRespondTests.cs
+++ b/RichardSzalay.MockHttp.Tests/MockedRequestExtentionsRespondTests.cs
@@ -131,6 +131,21 @@ namespace RichardSzalay.MockHttp.Tests
         }
 
         [Fact]
+        public void Respond_HttpStatus_headers_HttpContent()
+        {
+            var response = Test(r => r.Respond(HttpStatusCode.Found, new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            }, new StringContent("test", Encoding.UTF8, "text/plain")));
+
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
+        }
+
+        [Fact]
         public void Respond_mediaTypeString_contentStream()
         {
             MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes("test"));
@@ -143,6 +158,23 @@ namespace RichardSzalay.MockHttp.Tests
         }
 
         [Fact]
+        public void Respond_headers_mediaTypeString_contentStream()
+        {
+            MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+
+            var response = Test(r => r.Respond(new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            }, "text/plain", ms));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
+        }
+
+        [Fact]
         public void Respond_mediaTypeString_contentString()
         {
             var response = Test(r => r.Respond("text/plain", "test"));
@@ -150,6 +182,21 @@ namespace RichardSzalay.MockHttp.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
             Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+        }
+
+        [Fact]
+        public void Respond_headers_mediaTypeString_contentString()
+        {
+            var response = Test(r => r.Respond(new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            }, "text/plain", "test"));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
         }
 
         [Fact]
@@ -164,6 +211,24 @@ namespace RichardSzalay.MockHttp.Tests
             Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
         }
 
+
+        [Fact]
+        public void Respond_HttpStatusCode_headers_mediaTypeString_contentStream()
+        {
+            MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+
+            var response = Test(r => r.Respond(HttpStatusCode.PartialContent, new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            }, "text/plain", ms));
+
+            Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
+        }
+
         [Fact]
         public void Respond_HttpStatusCode_mediaTypeString_contentString()
         {
@@ -172,6 +237,21 @@ namespace RichardSzalay.MockHttp.Tests
             Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
             Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+        }
+
+        [Fact]
+        public void Respond_HttpStatusCode_headers_mediaTypeString_contentString()
+        {
+            var response = Test(r => r.Respond(HttpStatusCode.PartialContent, new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            },  "text/plain", "test"));
+
+            Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
         }
 
         [Fact]
@@ -185,6 +265,24 @@ namespace RichardSzalay.MockHttp.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
             Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+        }
+
+        [Fact]
+        public void Respond_HttpMessageHandler_headers()
+        {
+            var passthroughHandler = new MockHttpMessageHandler();
+            passthroughHandler.Fallback.Respond(new Dictionary<string, string> {
+                { "connection", "keep-alive" },
+                { "x-hello", "mockhttp" }
+            }, new StringContent("test", Encoding.UTF8, "text/plain"));
+
+            var response = Test(r => r.Respond(passthroughHandler));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("test", response.Content.ReadAsStringAsync().Result);
+            Assert.Equal("keep-alive", response.Headers.Connection.First());
+            Assert.Equal("mockhttp", response.Headers.GetValues("x-hello").First());
         }
 
         [Fact]


### PR DESCRIPTION
Hey Richard,

thanks for the library. I added the ability to add response headers using the MockedRequestExtensions. I always have lots of tests that involve checking the handling of response headers, so it would be great if you integrate it.

Thanks.
Sascha