### PR TITLE
Improve the default fallback handler

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -29,7 +29,10 @@ namespace RichardSzalay.MockHttp
 
             AutoFlush = true;
             fallback = new MockedRequest();
-            fallback.Respond(req => (fallbackResponse = CreateDefaultFallbackMessage()));
+            fallback.Respond(req => (fallbackResponse = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                ReasonPhrase = $"No matching mock handler for \"{req.Method.ToString().ToUpperInvariant()} {req.RequestUri.AbsoluteUri}\""
+            }));
         }
 
         private bool autoFlush;
@@ -212,13 +215,6 @@ namespace RichardSzalay.MockHttp
                 fallbackResponse = value;
                 fallback.Respond(value);
             }
-        }
-
-        HttpResponseMessage CreateDefaultFallbackMessage()
-        {
-            HttpResponseMessage message = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound);
-            message.ReasonPhrase = "No matching mock handler";
-            return message;
         }
 
         /// <summary>

--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -29,7 +29,7 @@ namespace RichardSzalay.MockHttp
 
             AutoFlush = true;
             fallback = new MockedRequest();
-            fallback.Respond(req => (fallbackResponse = CreateDefaultFallbackMessage(req)));
+            fallback.Respond(req => CreateDefaultFallbackMessage(req));
         }
 
         private bool autoFlush;

--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -180,7 +180,6 @@ namespace RichardSzalay.MockHttp
             }
         }
 
-        private HttpResponseMessage fallbackResponse = null;
         private MockedRequest fallback;
 
         /// <summary>
@@ -191,26 +190,6 @@ namespace RichardSzalay.MockHttp
             get
             {
                 return fallback;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the response that will be returned for requests that were not matched
-        /// </summary>
-        [Obsolete("Please use Fallback. FallbackResponse will be removed in a future release")]
-        public HttpResponseMessage FallbackResponse
-        {
-            get
-            {
-                return fallbackResponse;
-            }
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException();
-
-                fallbackResponse = value;
-                fallback.Respond(value);
             }
         }
 

--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -29,10 +29,7 @@ namespace RichardSzalay.MockHttp
 
             AutoFlush = true;
             fallback = new MockedRequest();
-            fallback.Respond(req => (fallbackResponse = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
-            {
-                ReasonPhrase = $"No matching mock handler for \"{req.Method.ToString().ToUpperInvariant()} {req.RequestUri.AbsoluteUri}\""
-            }));
+            fallback.Respond(req => (fallbackResponse = CreateDefaultFallbackMessage(req)));
         }
 
         private bool autoFlush;
@@ -215,6 +212,15 @@ namespace RichardSzalay.MockHttp
                 fallbackResponse = value;
                 fallback.Respond(value);
             }
+        }
+
+        HttpResponseMessage CreateDefaultFallbackMessage(HttpRequestMessage req)
+        {
+            var message = new HttpResponseMessage(System.Net.HttpStatusCode.NotFound)
+            {
+                ReasonPhrase = $"No matching mock handler for \"{req.Method.ToString().ToUpperInvariant()} {req.RequestUri.AbsoluteUri}\""
+            };
+            return message;
         }
 
         /// <summary>

--- a/RichardSzalay.MockHttp.Tests/MockHttpMessageHandlerTests.cs
+++ b/RichardSzalay.MockHttp.Tests/MockHttpMessageHandlerTests.cs
@@ -158,26 +158,6 @@ namespace RichardSzalay.MockHttp.Tests
         }
 
         [Fact]
-        public void Should_return_fallbackresponse_for_unmatched_requests()
-        {
-            var mockHandler = new MockHttpMessageHandler();
-            var client = new HttpClient(mockHandler);
-
-            mockHandler
-                .When("/test")
-                .Respond(System.Net.HttpStatusCode.OK, "application/json", "{'status' : 'OK'}");
-
-            mockHandler.FallbackResponse = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
-            {
-                ReasonPhrase = "Awesome"
-            };
-
-            var result = client.GetAsync("http://invalid/test2").Result;
-
-            Assert.Equal("Awesome", result.ReasonPhrase);
-        }
-
-        [Fact]
         public void Should_match_expect_before_when()
         {
             var mockHandler = new MockHttpMessageHandler();
@@ -217,25 +197,6 @@ namespace RichardSzalay.MockHttp.Tests
 
             Assert.Equal("{'status' : 'First'}", result1.Content.ReadAsStringAsync().Result);
             Assert.Equal("{'status' : 'Second'}", result2.Content.ReadAsStringAsync().Result);
-        }
-
-        [Fact]
-        public void Should_not_match_expect_out_of_order()
-        {
-            var mockHandler = new MockHttpMessageHandler();
-            var client = new HttpClient(mockHandler);
-
-            mockHandler
-                .Expect("/test1")
-                .Respond("application/json", "{'status' : 'First'}");
-
-            mockHandler
-                .Expect("/test2")
-                .Respond("application/json", "{'status' : 'Second'}");
-
-            var result = client.GetAsync("http://invalid/test2").Result;
-
-            Assert.Equal(mockHandler.FallbackResponse.StatusCode, result.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
Include the HTTP verb and the URL in the exception if no matching mock handler is found

Resolves #57 