### PR TITLE
Throw InvalidOperationException if response is ever null on MockedRequest.

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockedRequest.cs
+++ b/RichardSzalay.MockHttp.Shared/MockedRequest.cs
@@ -85,10 +85,16 @@ namespace RichardSzalay.MockHttp
         /// </summary>
         /// <param name="message">The request being sent</param>
         /// <param name="cancellationToken">The token used to cancel the request</param>
+        /// <exception cref="InvalidOperationException">A response was not configured for this request</exception>
         /// <returns>A Task containing the future response message</returns>
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage message, CancellationToken cancellationToken)
         {
-            return response(message);
+            if (this.response is null)
+            {
+                throw new InvalidOperationException("A response was not configured for this request");
+            }
+
+            return this.response(message);
         }
     }
 }

--- a/RichardSzalay.MockHttp.Tests/Issues/Issue86Tests.cs
+++ b/RichardSzalay.MockHttp.Tests/Issues/Issue86Tests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RichardSzalay.MockHttp.Tests.Issues
+{
+    public class Issue86Tests
+    {
+        [Fact]
+        public async Task Forgetting_to_configure_response_throws()
+        {
+            // Given
+            var mockHttp = new MockHttp();
+            mockHttp.Expect("/foo")
+                .WithQueryString("bar", "bat")
+                .WithQueryString("fizz", "buzz");
+            var httpClient = mockHttp.ToHttpClient();
+
+            // When
+            var exception = Record.Exception(() => httpClient.GetAsync("/foo"));
+
+            // Then
+            Assert.NotNull(exception);
+            Assert.IsType<InvalidOperationException>(exception);
+            Assert.Equal("A response was not configured for this request", exception.message);
+        }
+    }
+}


### PR DESCRIPTION
If a request is configured, but a response is never configured, throw a meaningful exception.

```csharp
mockHttp.Expect("/foo")
        .WithQueryString("bar", "bat")
        .WithQueryString("fizz", "buzz");
        // forgot to configure response

httpClient.GetAsync("/foo"); // throws NullReferenceException.
```