### PR TITLE
new feature 'ThenRespond'

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockedRequestExtensions.cs
+++ b/RichardSzalay.MockHttp.Shared/MockedRequestExtensions.cs
@@ -339,6 +339,18 @@ namespace RichardSzalay.MockHttp
         }
 
         /// <summary>
+        /// Sets the next response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="mediaType">The media type of the response</param>
+        /// <param name="content">The content of the response</param>
+        public static MockedRequest ThenRespond(this MockedRequest source, HttpStatusCode statusCode, string mediaType, string content)
+        {
+            return source.ThenRespond(statusCode, Enumerable.Empty<KeyValuePair<string, string>>(), mediaType, content);
+        }
+
+        /// <summary>
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
@@ -349,6 +361,19 @@ namespace RichardSzalay.MockHttp
         public static MockedRequest Respond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, string content)
         {
             return source.Respond(statusCode, headers, _ => new StringContent(content, Encoding.UTF8, mediaType));
+        }
+
+        /// <summary>
+        /// Sets the next response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="mediaType">The media type of the response</param>
+        /// <param name="content">The content of the response</param>
+        public static MockedRequest ThenRespond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, string mediaType, string content)
+        {
+            return source.ThenRespond(statusCode, headers, _ => new StringContent(content, Encoding.UTF8, mediaType));
         }
 
         /// <summary>
@@ -549,6 +574,29 @@ namespace RichardSzalay.MockHttp
         }
 
         /// <summary>
+        /// Sets the next response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="statusCode">The <see cref="T:HttpStatusCode"/> of the response</param>
+        /// <param name="headers">A list of HTTP header name/value pairs to add to the response.</param>
+        /// <param name="handler">The delegate that will return a <see cref="T:HttpContent"/> determined at runtime</param>
+        public static MockedRequest ThenRespond(this MockedRequest source, HttpStatusCode statusCode, IEnumerable<KeyValuePair<string, string>> headers, Func<HttpRequestMessage, HttpContent> handler)
+        {
+            return source.ThenRespond(req =>
+            {
+                var res = new HttpResponseMessage(statusCode)
+                {
+                    Content = handler(req),
+                };
+                foreach (var header in headers)
+                {
+                    res.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+                return res;
+            });
+        }
+
+        /// <summary>
         /// Sets the response of the current <see cref="T:MockedRequest"/>
         /// </summary>
         /// <param name="source">The source mocked request</param>
@@ -556,6 +604,16 @@ namespace RichardSzalay.MockHttp
         public static MockedRequest Respond(this MockedRequest source, Func<HttpRequestMessage, HttpResponseMessage> handler)
         {
             return source.Respond(req => TaskEx.FromResult(handler(req)));
+        }
+
+        /// <summary>
+        /// Sets the next response of the current <see cref="T:MockedRequest"/>
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="handler">The delegate that will return a <see cref="T:HttpResponseMessage"/> determined at runtime</param>
+        public static MockedRequest ThenRespond(this MockedRequest source, Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            return source.ThenRespond(req => TaskEx.FromResult(handler(req)));
         }
 
         /// <summary>
@@ -576,6 +634,17 @@ namespace RichardSzalay.MockHttp
         public static MockedRequest Respond(this MockedRequest source, HttpMessageHandler handler)
         {
             return source.Respond(new HttpClient(handler));
+        }
+
+        /// <summary>
+        /// Sets the next response of the current <see cref="T:MockedRequest"/>, with an OK (200) status code
+        /// </summary>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="content">The content of the response</param>
+        /// <param name="mediaType">The media type of the response</param>
+        public static MockedRequest ThenRespond(this MockedRequest source, string mediaType, string content)
+        {
+            return source.ThenRespond(HttpStatusCode.OK, mediaType, content);
         }
 
         /// <summary>

--- a/RichardSzalay.MockHttp.Tests/MockHttpMessageHandlerTests.cs
+++ b/RichardSzalay.MockHttp.Tests/MockHttpMessageHandlerTests.cs
@@ -48,6 +48,44 @@ namespace RichardSzalay.MockHttp.Tests
         }
 
         [Fact]
+        public void Should_support_then_respond_with_basic_requests()
+        {
+            var mockHandler = new MockHttpMessageHandler();
+
+            mockHandler
+                .When("/test")
+                .Respond("application/json", "{'status' : 'OK'}")
+                .ThenRespond("application/json", "{'status' : 'OK1'}")
+                .ThenRespond("text/plain", "=OK2=");
+
+            var result1 = new HttpClient(mockHandler).GetAsync("http://invalid/test").Result;
+            var result2 = new HttpClient(mockHandler).GetAsync("http://invalid/test").Result;
+            var result3 = new HttpClient(mockHandler).GetAsync("http://invalid/test").Result;
+            var result4 = new HttpClient(mockHandler).GetAsync("http://invalid/test").Result;
+            var result5 = new HttpClient(mockHandler).GetAsync("http://invalid/test").Result;
+
+            Assert.Equal(HttpStatusCode.OK, result1.StatusCode);
+            Assert.Equal("application/json", result1.Content.Headers.ContentType.MediaType);
+            Assert.Equal("{'status' : 'OK'}", result1.Content.ReadAsStringAsync().Result);
+
+            Assert.Equal(HttpStatusCode.OK, result2.StatusCode);
+            Assert.Equal("application/json", result2.Content.Headers.ContentType.MediaType);
+            Assert.Equal("{'status' : 'OK1'}", result2.Content.ReadAsStringAsync().Result);
+
+            Assert.Equal(HttpStatusCode.OK, result3.StatusCode);
+            Assert.Equal("text/plain", result3.Content.Headers.ContentType.MediaType);
+            Assert.Equal("=OK2=", result3.Content.ReadAsStringAsync().Result);
+
+            Assert.Equal(HttpStatusCode.OK, result4.StatusCode);
+            Assert.Equal("application/json", result4.Content.Headers.ContentType.MediaType);
+            Assert.Equal("{'status' : 'OK'}", result4.Content.ReadAsStringAsync().Result);
+
+            Assert.Equal(HttpStatusCode.OK, result5.StatusCode);
+            Assert.Equal("application/json", result5.Content.Headers.ContentType.MediaType);
+            Assert.Equal("{'status' : 'OK'}", result5.Content.ReadAsStringAsync().Result);
+        }
+
+        [Fact]
         public void Should_assign_request_to_response_object()
         {
             var mockHandler = new MockHttpMessageHandler();


### PR DESCRIPTION
http apis are not always idempotent. As a developer, I would like the library to allow the user to set multiple responses, which will be returned in the order given by the user.

This pr can support it. If the user sets 2 'ThenRespond', the first time will return 'Respond' as before, the second and third time will return 'ThenRespond', when the user continues the request, it will always return 'Respond'. (just like the test code I wrote)