### PR TITLE
Fix outstanding requests exception message

### DIFF
--- a/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
+++ b/RichardSzalay.MockHttp.Shared/MockHttpMessageHandler.cs
@@ -267,8 +267,9 @@ namespace RichardSzalay.MockHttp
         /// </summary>
         public void VerifyNoOutstandingRequest()
         {
-            if (outstandingRequests > 0)
-                throw new InvalidOperationException("There are " + outstandingRequests + " oustanding requests. Call Flush() to complete them");
+            var requests = Interlocked.CompareExchange(ref outstandingRequests, 0, 0);
+            if (requests > 0)
+                throw new InvalidOperationException("There are " + requests + " outstanding requests. Call Flush() to complete them");
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes a concurrency issue where between lines `outstandingRequests > 0` and `throw new InvalidOperationException` another thread would increment/decrement `outstandingRequests`. See https://stackoverflow.com/a/24893231
Fixes `oustanding` to `outstanding` in the exception message.