### PR TITLE
Json matchers (.NET 5+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Passing an HTTP method and URL to `When` or `Expect` is equivalent to applying a
 | <pre>WithContent("{'name':'McGee'}")</pre> | Matches on the (post) content of the request |
 | <pre>WithPartialContent("McGee")</pre> | Matches on the partial (post) content of the request |
 | <pre>WithHeaders("Authorization", "Basic abcdef")<br /><br />WithHeaders(@"Authorization: Basic abcdef<br />Accept: application/json")<br /><br />WithHeaders(new Dictionary&lt;string,string><br />{<br />  { "Authorization", "Basic abcdef" },<br />  { "Accept", "application/json" }<br />})<br /></pre> | Matches on one or more HTTP header values |
+| <pre>WithJsonContent&lt;T>(new MyTypedRequest() [, jsonSerializerSettings])<br /><br />WithJsonContent&lt;T>(t => t.SomeProperty == 5 [, jsonSerializerSettings])</pre> | Matches on requests that have matching JSON content |
 | <pre>With(request => request.Content.Length > 50)</pre> | Applies custom matcher logic against an HttpRequestMessage |
 
 These methods are chainable, making complex requirements easy to descirbe.

--- a/RichardSzalay.MockHttp.Tests/Matchers/JsonContentMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/JsonContentMatcherTests.cs
@@ -1,0 +1,50 @@
+﻿using RichardSzalay.MockHttp.Matchers;
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using Xunit;
+
+namespace RichardSzalay.MockHttp.Tests.Matchers
+{
+    public class JsonContentMatcherTests
+    {
+        [Fact]
+        public void Should_succeed_when_predicate_returns_true()
+        {
+            var result = Test(
+                expected: c => c.Value == true,
+                actual: new JsonContent(true)
+                );
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Should_fail_when_predicate_returns_false()
+        {
+            var result = Test(
+                expected: c => c.Value == false,
+                actual: new JsonContent(true)
+                );
+
+            Assert.False(result);
+        }
+
+        private bool Test(Func<JsonContent, bool> expected, JsonContent actual)
+        {
+            var options = new JsonSerializerOptions();
+
+            var sut = new JsonContentMatcher<JsonContent>(expected, options);
+
+            StringContent content = new StringContent(
+                JsonSerializer.Serialize(actual, options)
+                );
+
+            return sut.Matches(new HttpRequestMessage(HttpMethod.Get,
+                "http://tempuri.org/home")
+            { Content = content });
+        }
+
+        public record JsonContent(bool Value);
+    }
+}

--- a/RichardSzalay.MockHttp/Matchers/JsonContentMatcher.cs
+++ b/RichardSzalay.MockHttp/Matchers/JsonContentMatcher.cs
@@ -1,0 +1,60 @@
+﻿#if NET5_0_OR_GREATER
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+
+namespace RichardSzalay.MockHttp.Matchers
+{
+    /// <summary>
+    /// Matches requests on a predicate-based match of its JSON content
+    /// </summary>
+    /// <typeparam name="T">The deserialized type that will be used for comparison</typeparam>
+    public class JsonContentMatcher<T> : IMockedRequestMatcher
+    {
+        private readonly JsonSerializerOptions serializerOptions;
+        private readonly Func<T, bool> predicate;
+
+        /// <summary>
+        /// Constructs a new instance of JsonContentMatcher using a predicate to be used for comparison
+        /// </summary>
+        /// <param name="predicate">The predicate that will be used to match the deserialized request content</param>
+        /// <param name="serializerOptions">Optional. Provide the <see cref="JsonSerializerOptions"/> that will be used to deserialize the request content for comparison.</param>
+        public JsonContentMatcher(Func<T, bool> predicate, JsonSerializerOptions serializerOptions = null)
+        {
+            this.serializerOptions = serializerOptions;
+            this.predicate = predicate;
+        }
+
+        /// <summary>
+        /// Determines whether the implementation matches a given request
+        /// </summary>
+        /// <param name="message">The request message being evaluated</param>
+        /// <returns>true if the request was matched; false otherwise</returns>
+        public bool Matches(HttpRequestMessage message)
+        {
+            if (message.Content == null)
+            {
+                return false;
+            }
+
+            var deserializedContent = Deserialize(message.Content.ReadAsStream());
+
+            return predicate(deserializedContent);
+        }
+
+        private T Deserialize(Stream stream)
+        {
+#if NET5_0
+            return JsonSerializer.DeserializeAsync<T>(stream, serializerOptions)
+                .GetAwaiter().GetResult();
+#else
+            return JsonSerializer.Deserialize<T>(stream, serializerOptions);
+#endif
+        }
+
+    }
+}
+
+#endif

--- a/RichardSzalay.MockHttp/MockedRequestJsonExtensions.cs
+++ b/RichardSzalay.MockHttp/MockedRequestJsonExtensions.cs
@@ -1,0 +1,46 @@
+﻿#if NET5_0_OR_GREATER
+using System;
+using System.Text.Json;
+using RichardSzalay.MockHttp.Matchers;
+
+namespace RichardSzalay.MockHttp
+{
+    /// <summary>
+    /// Provides JSON-related extension methods for <see cref="T:MockedRequest"/>
+    /// </summary>
+    public static class MockedRequestJsonExtensions
+    {
+        /// <summary>
+        /// Requires that the request content contains JSON that matches <paramref name="content"/>
+        /// </summary>
+        /// <remarks>
+        /// The request content must exactly match the serialized JSON of <paramref name="content"/>
+        /// </remarks>
+        /// <typeparam name="T">The type that represents the JSON request</typeparam>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="content">The value that, when serialized to JSON, must match the request content</param>
+        /// <param name="serializerOptions">Optional. Provide the <see cref="JsonSerializerOptions"/> that will be used to serialize <paramref name="content"/> for comparison.</param>
+        /// <returns></returns>
+        public static MockedRequest WithJsonContent<T>(this MockedRequest source, T content, JsonSerializerOptions serializerOptions = null)
+        {
+            var serializedJson = JsonSerializer.Serialize(content, serializerOptions);
+
+            return source.WithContent(serializedJson);
+        }
+
+        /// <summary>
+        /// Requires that the request content contains JSON that, when deserialized, matches <paramref name="predicate"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="predicate">The predicate that will be used to match the deserialized request content</param>
+        /// <param name="serializerOptions">Optional. Provide the <see cref="JsonSerializerOptions"/> that will be used to deserialize the request content for comparison.</param>
+        /// <returns>The <see cref="T:MockedRequest"/> instance</returns>
+        public static MockedRequest WithJsonContent<T>(this MockedRequest source, Func<T, bool> predicate, JsonSerializerOptions serializerOptions = null)
+        {
+            return source.With(new JsonContentMatcher<T>(predicate, serializerOptions));
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
* `WithJsonContent<T>(T value, JsonSerializerOptions? options = null)` - serialize the input and then match on that exact string content in the request
* `WithJsonContent<T>(Func<T, bool> value, JsonSerializerOptions? options = null)` - deserialize the request content and then match the result against the provided predicate.

NOTE: Due to netstandard/TFM shenanigans this feature is only available on .NET 5 or later.