### PR TITLE
Xml matchers

### DIFF
--- a/RichardSzalay.MockHttp.Tests/Matchers/XmlContentMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/XmlContentMatcherTests.cs
@@ -1,0 +1,57 @@
+﻿using RichardSzalay.MockHttp.Matchers;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Xml.Serialization;
+using Xunit;
+
+namespace RichardSzalay.MockHttp.Tests.Matchers
+{
+    public class XmlContentMatcherTests
+    {
+        private static XmlSerializer xmlSerializer = new XmlSerializer(typeof(XmlContent));
+
+        [Fact]
+        public void Should_succeed_when_predicate_returns_true()
+        {
+            var result = Test(
+                expected: c => c.Value == true,
+                actual: new XmlContent { Value = true }
+                );
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Should_fail_when_predicate_returns_false()
+        {
+            var result = Test(
+                expected: c => c.Value == false,
+                actual: new XmlContent { Value = true }
+                );
+
+            Assert.False(result);
+        }
+
+        private bool Test(Func<XmlContent, bool> expected, XmlContent actual)
+        {
+            var sut = new XmlContentMatcher<XmlContent>(expected);
+
+            var ms = new MemoryStream();
+            var sw = new StreamWriter(ms);
+            xmlSerializer.Serialize(sw, actual);
+
+            StringContent content = new StringContent(Encoding.UTF8.GetString(ms.ToArray()));
+
+            return sut.Matches(new HttpRequestMessage(HttpMethod.Get,
+                "http://tempuri.org/home")
+            { Content = content });
+        }
+
+        public class XmlContent
+        {
+            public bool Value { get; set; }
+        }
+    }
+}

--- a/RichardSzalay.MockHttp/Matchers/XmlContentMatcher.cs
+++ b/RichardSzalay.MockHttp/Matchers/XmlContentMatcher.cs
@@ -1,0 +1,70 @@
+﻿#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Xml.Serialization;
+
+namespace RichardSzalay.MockHttp.Matchers
+{
+    /// <summary>
+    /// Matches requests on a predicate-based match of its Xml content
+    /// </summary>
+    /// <typeparam name="T">The deserialized type that will be used for comparison</typeparam>
+    public class XmlContentMatcher<T> : IMockedRequestMatcher
+    {
+        private readonly XmlSerializer serializer;
+        private readonly Func<T, bool> predicate;
+
+        /// <summary>
+        /// Constructs a new instance of XmlContentMatcher using a predicate to be used for comparison
+        /// </summary>
+        /// <param name="predicate">The predicate that will be used to match the deserialized request content</param>
+        /// <param name="serializer">Optional. Provide the <see cref="XmlSerializer"/> that will be used to deserialize the request content for comparison.</param>
+        public XmlContentMatcher(Func<T, bool> predicate, XmlSerializer serializer = null)
+        {
+            this.serializer = serializer ?? XmlContentMatcher.CreateSerializer(typeof(T));
+            this.predicate = predicate;
+        }
+
+        /// <summary>
+        /// Determines whether the implementation matches a given request
+        /// </summary>
+        /// <param name="message">The request message being evaluated</param>
+        /// <returns>true if the request was matched; false otherwise</returns>
+        public bool Matches(HttpRequestMessage message)
+        {
+            if (message.Content == null)
+            {
+                return false;
+            }
+
+            var stream = message.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+            var deserializedContent = Deserialize(stream);
+
+            return predicate(deserializedContent);
+        }
+
+        private T Deserialize(Stream stream)
+        {
+            return (T)serializer.Deserialize(stream);
+        }
+    }
+
+    /// <summary>
+    /// Static class to house an XmlSerializerFactory instance
+    /// </summary>
+    public static class XmlContentMatcher
+    {
+        private static XmlSerializerFactory SerializerFactory { get; } = new XmlSerializerFactory();
+
+        /// <summary>
+        /// Create a default instance of XmlSerializer for the given type
+        /// </summary>
+        /// <param name="type">The type to be serialized</param>
+        public static XmlSerializer CreateSerializer(Type type)
+        {
+            return SerializerFactory.CreateSerializer(type);
+        }
+    }
+}
+#endif

--- a/RichardSzalay.MockHttp/MockedRequestXmlExtensions.cs
+++ b/RichardSzalay.MockHttp/MockedRequestXmlExtensions.cs
@@ -1,0 +1,55 @@
+﻿#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+using RichardSzalay.MockHttp.Matchers;
+
+namespace RichardSzalay.MockHttp
+{
+    /// <summary>
+    /// Provides XML-related extension methods for <see cref="T:MockedRequest"/>
+    /// </summary>
+    public static class MockedRequestXmlExtensions
+    {
+        /// <summary>
+        /// Requires that the request content contains Xml that matches <paramref name="content"/>
+        /// </summary>
+        /// <remarks>
+        /// The request content must exactly match the serialized Xml of <paramref name="content"/>
+        /// </remarks>
+        /// <typeparam name="T">The type that represents the Xml request</typeparam>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="content">The value that, when serialized to Xml, must match the request content</param>
+        /// <param name="serializer">Optional. Provide the <see cref="XmlSerializer"/> that will be used to serialize <paramref name="content"/> for comparison.</param>
+        /// <param name="settings">Optional. Provide the <see cref="XmlWriterSettings"/> that will be used to serialize <paramref name="content"/> for comparison.</param>
+        /// <returns></returns>
+        public static MockedRequest WithXmlContent<T>(this MockedRequest source, T content, XmlSerializer serializer = null, XmlWriterSettings settings = null)
+        {
+            serializer = serializer ?? XmlContentMatcher.CreateSerializer(typeof(T));
+
+            var ms = new MemoryStream();
+            var writer = new StreamWriter(ms);
+            var xmlWriter = XmlWriter.Create(writer, settings);
+            serializer.Serialize(xmlWriter, content);
+
+            return source.WithContent(Encoding.UTF8.GetString(ms.ToArray()));
+        }
+
+        /// <summary>
+        /// Requires that the request content contains Xml that, when deserialized, matches <paramref name="predicate"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source">The source mocked request</param>
+        /// <param name="predicate">The predicate that will be used to match the deserialized request content</param>
+        /// <param name="serializer">Optional. Provide the <see cref="XmlSerializer"/> that will be used to deserialize the request content for comparison.</param>
+        /// <returns>The <see cref="T:MockedRequest"/> instance</returns>
+        public static MockedRequest WithXmlContent<T>(this MockedRequest source, Func<T, bool> predicate, XmlSerializer serializer = null)
+        {
+            return source.With(new XmlContentMatcher<T>(predicate, serializer));
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
* `WithXmlContent<T>(T value, XmlSerializer? serializer = null, XmlWriterSettings? settings = null)` - serialize the input and then match on that exact string content in the request
* `WithXmlContent<T>(Func<T, bool> value, XmlSerializer? serializer = null)` - deserialize the request content and then match the result against the provided predicate.

NOTE: This feature is only available to [.NET Standard 2.0 and above](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version)