### PR TITLE
Bugfix/exact match empty query

### DIFF
--- a/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
@@ -111,6 +111,18 @@ public class QueryStringMatcherTests
         Assert.True(actualMatch, "QueryStringMatcher.Matches() should match dictionary data with URL encoded query string values.");
     }
 
+    [Fact]
+    public void Should_support_matching_with_empty_dictionary_data_when_exact_is_true()
+    {
+        var data = new Dictionary<string, string>();
+        
+        var sut = new QueryStringMatcher(data, true);
+
+        var actualMatch = sut.Matches(new HttpRequestMessage(HttpMethod.Get, "http://tempuri.org/home"));
+
+        Assert.True(actualMatch, "QueryStringMatcher.Matches() should match empty dictionary data.");
+    }
+
     private bool Test(string expected, string actual, bool exact = false)
     {
         var sut = new QueryStringMatcher(expected, exact);

--- a/RichardSzalay.MockHttp/Matchers/QueryStringMatcher.cs
+++ b/RichardSzalay.MockHttp/Matchers/QueryStringMatcher.cs
@@ -69,7 +69,12 @@ public class QueryStringMatcher : IMockedRequestMatcher
 
     internal static IEnumerable<KeyValuePair<string, string>> ParseQueryString(string input)
     {
-        return input.TrimStart('?').Split('&')
+        if (input.Length == 0)
+        {
+            return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+        return input.TrimStart('?')
+            .Split('&')
             .Select(pair => StringUtil.Split(pair, '=', 2))
             .Select(pair => new KeyValuePair<string, string>(
                 UrlDecode(pair[0]),


### PR DESCRIPTION
This PR adds a fix for QueryMatcher where any empty KeyValuePair would fail an exact match check when the HttpRequestMessage.RequestUri.Query is empty. 