### PR TITLE
Feature Query String Matcher Comparisons

### DIFF
--- a/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherOptionsTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherOptionsTests.cs
@@ -1,0 +1,56 @@
+﻿using RichardSzalay.MockHttp.Matchers;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace RichardSzalay.MockHttp.Tests.Matchers;
+
+public class QueryStringMatcherOptionsTests
+{
+    [Fact]
+    public void Should_default_to_ordinal_key_comparison()
+    {
+        // act
+        var sut = new QueryStringMatcherOptions();
+
+        // assert
+        Assert.Equal(StringComparer.Ordinal, sut.KeyComparer);
+    }
+
+    [Fact]
+    public void Should_default_to_ordinal_value_comparison()
+    {
+        // act
+        var sut = new QueryStringMatcherOptions();
+
+        // assert
+        Assert.Equal(StringComparer.Ordinal, sut.ValueComparer);
+    }
+
+    [Theory]
+    [MemberData(nameof(ConstructorTheoryData))]
+    public void Should_initialize_comparers_correctly(IEqualityComparer<string>? key, IEqualityComparer<string>? value, IEqualityComparer<string> expectedKey, IEqualityComparer<string> expectedValue)
+    {
+        // act
+        var sut = new QueryStringMatcherOptions(key, value);
+
+        // assert
+        Assert.Equal(expectedKey, sut.KeyComparer);
+        Assert.Equal(expectedValue, sut.ValueComparer);
+    }
+
+    public static IEnumerable<object?[]> ConstructorTheoryData
+    {
+        get
+        {
+            // nulls default to Ordinal
+            yield return new object?[] { null, null, StringComparer.Ordinal, StringComparer.Ordinal };
+            // set value comparer, should be correct
+            yield return new object?[] { null, StringComparer.OrdinalIgnoreCase, StringComparer.Ordinal, StringComparer.OrdinalIgnoreCase };
+            // set value comparer, should be correct
+            yield return new object?[] { StringComparer.OrdinalIgnoreCase, null, StringComparer.OrdinalIgnoreCase, StringComparer.Ordinal };
+            // set both comparers, should be correct
+            yield return new object?[] { StringComparer.OrdinalIgnoreCase, StringComparer.InvariantCultureIgnoreCase, StringComparer.OrdinalIgnoreCase, StringComparer.InvariantCultureIgnoreCase };
+        }
+    }
+}

--- a/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
+++ b/RichardSzalay.MockHttp.Tests/Matchers/QueryStringMatcherTests.cs
@@ -1,4 +1,5 @@
 ﻿using RichardSzalay.MockHttp.Matchers;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using Xunit;
@@ -111,9 +112,33 @@ public class QueryStringMatcherTests
         Assert.True(actualMatch, "QueryStringMatcher.Matches() should match dictionary data with URL encoded query string values.");
     }
 
-    private bool Test(string expected, string actual, bool exact = false)
+    [Fact]
+    public void Should_not_fail_when_keys_have_different_case_and_using_options()
     {
-        var sut = new QueryStringMatcher(expected, exact);
+        bool result = Test(
+            expected: "key1=value1&key2=value2",
+            actual: "Key1=value1&Key2=value2",
+            options: new QueryStringMatcherOptions(key: StringComparer.OrdinalIgnoreCase)
+            );
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_not_fail_when_values_have_different_case_and_using_options()
+    {
+        bool result = Test(
+            expected: "key1=value1&key2=value2",
+            actual: "key1=Value1&key2=Value2",
+            options: new QueryStringMatcherOptions(value: StringComparer.OrdinalIgnoreCase)
+            );
+
+        Assert.True(result);
+    }
+
+    private bool Test(string expected, string actual, bool exact = false, QueryStringMatcherOptions? options = null)
+    {
+        var sut = new QueryStringMatcher(expected, exact, options);
 
         return sut.Matches(new HttpRequestMessage(HttpMethod.Get,
             "http://tempuri.org/home?" + actual));

--- a/RichardSzalay.MockHttp/Matchers/QueryStringMatcherOptions.cs
+++ b/RichardSzalay.MockHttp/Matchers/QueryStringMatcherOptions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace RichardSzalay.MockHttp.Matchers;
+
+/// <summary>
+/// Provides options on how to match query strings.
+/// </summary>
+public sealed class QueryStringMatcherOptions
+{
+    /// <summary>
+    /// Constructs a new instance of QueryStringMatcherOptions using the default ordinal comparison on keys and values.
+    /// </summary>
+    public QueryStringMatcherOptions() : this(StringComparer.Ordinal, StringComparer.Ordinal)
+    {
+    }
+
+    /// <summary>
+    /// Constructs a new instance of QueryStringMatcherOptions using the default ordinal comparison on keys and values.
+    /// </summary>
+    /// <param name="key">The comparer to use for keys, or null to use the default StringComparer.Ordinal</param>
+    /// <param name="value">The comparer to use for values, or null to use the default StringComparer.Ordinal</param>
+    public QueryStringMatcherOptions(IEqualityComparer<string>? key = null, IEqualityComparer<string>? value = null)
+    {
+        KeyComparer = key ?? StringComparer.Ordinal;
+        ValueComparer = value ?? StringComparer.Ordinal;
+    }
+
+    /// <summary>
+    /// The comparer to use for keys
+    /// </summary>
+    public IEqualityComparer<string> KeyComparer { get; }
+
+    /// <summary>
+    /// The comparer to use for values
+    /// </summary>
+    public IEqualityComparer<string> ValueComparer { get; }
+}


### PR DESCRIPTION
This is initial version of being able to add string comparisons for query strings. It is to address #134.  There is still more work that will need to be done before this should be merged.  Additional unit tests and examples should be added as well.  I still need to add optional parameters to the extension methods. Please consider this PR as draft. I would appreciate any feedback on the design and any changes you would like to see.

### Example

Proposed extension method change:

```cs
public static MockedRequest WithQueryString(this MockedRequest source, string name, string value, QueryStringMatcherOptions? options = null);
```

Usage

```cs
mockHttp.Expect("/users/me")
        .WithQueryString("access_token", "Old_Token", options: new QueryStringMatcherOptions(value: StringComparer.OrdinalIgnoreCase))
        .Respond(HttpStatusCode.Unauthorized);
```

### QueryStringMatcherOptions

```cs
/// <summary>
/// Provides options on how to match query strings.
/// </summary>
public sealed class QueryStringMatcherOptions
{
    /// <summary>
    /// Constructs a new instance of QueryStringMatcherOptions using the default ordinal comparison on keys and values.
    /// </summary>
    public QueryStringMatcherOptions() : this(StringComparer.Ordinal, StringComparer.Ordinal)
    {
    }

    /// <summary>
    /// Constructs a new instance of QueryStringMatcherOptions using the default ordinal comparison on keys and values.
    /// </summary>
    public QueryStringMatcherOptions(IEqualityComparer<string>? key = null, IEqualityComparer<string>? value = null)
    {
        KeyComparer = key ?? StringComparer.Ordinal;
        ValueComparer = value ?? StringComparer.Ordinal;
    }

    /// <summary>
    /// The comparer to use for keys
    /// </summary>
    public IEqualityComparer<string> KeyComparer { get; }

    /// <summary>
    /// The comparer to use for values
    /// </summary>
    public IEqualityComparer<string> ValueComparer { get; }
}
```

